### PR TITLE
@ashleykrista => Adds support for custom header image source links.

### DIFF
--- a/source/blog/2014-10-22-fresh-coat-of-paint.html.erb
+++ b/source/blog/2014-10-22-fresh-coat-of-paint.html.erb
@@ -2,6 +2,7 @@
 title: Fresh Coat of Paint
 date: 2014-10-22 11:56 UTC
 background_image: /img/blog/fresh-coat-of-paint/Fresh-Coat-of-Paint.jpg
+background_image_source: https://500px.com/photo/43500268/the-hurricane-iii-by-ash-furrow
 layout: custom_blog_post
 summary: "<p>A few months ago, I felt something change. I remember it precisely: I asked a friend for advice designing a portfolio section of my website, and I couldn’t implement his suggestions. This wasn’t the first time that tools have limited my ability to express my ideas on the web, but it was a catalyst for what you see today: a brand new website. </p>"
 ---

--- a/source/blog/2014-11-16-lessons-learned-travelling-europe.html.markdown
+++ b/source/blog/2014-11-16-lessons-learned-travelling-europe.html.markdown
@@ -2,6 +2,7 @@
 title: Lessons Learned Travelling Europe
 date: 2014-11-16 11:16:06 UTC
 background_image: /img/blog/lessons-learned-travelling-europe/tower.jpg
+background_image_source: https://500px.com/photo/66654595/tour-by-ash-furrow
 ---
 
 Almost a year ago, my wife and I decided to move from Toronto to Amsterdam. Why? I can’t really remember anymore, but when people ask me I tell them we moved because we wanted to see more of the world and have an adventure. 

--- a/source/blog/2014-12-07-the-state-of-photography-in-2014.html.markdown
+++ b/source/blog/2014-12-07-the-state-of-photography-in-2014.html.markdown
@@ -2,6 +2,7 @@
 title: The State of Photography in 2014
 date: 2014-12-07 21:46:13 UTC
 background_image: /img/blog/the-state-of-photography-in-2014/background.jpg
+background_image_source: https://500px.com/photo/63919867/leica-lady-by-ash-furrow
 og_image: /img/blog/the-state-of-photography-in-2014/og.jpg
 ---
 

--- a/source/blog/2014-12-21-5-years-of-ios.html.erb
+++ b/source/blog/2014-12-21-5-years-of-ios.html.erb
@@ -2,7 +2,7 @@
 title: 5 Years of iOS
 date: 2014-12-21 20:50:18 UTC
 layout: custom_blog_post
-header_image: /img/blog/5-years-of-ios/header.jpg
+background_image: /img/blog/5-years-of-ios/header.jpg
 summary: In December, 2009, I started doing iOS development. That means that this month – almost to the day – I’ve been doing iOS for five years, meaning I’m finally qualified for an entry-level corporate job requiring 5-7 years experience. Kidding aside, I thought it would be nice to look back on the past half-decade of my life and pick out some events that were important to getting me where I am today.
 timeline: true
 ---

--- a/source/blog/2015-01-02-technology-meets-art.html.markdown
+++ b/source/blog/2015-01-02-technology-meets-art.html.markdown
@@ -1,7 +1,8 @@
 ---
 title: Technology Meets Art
 date: 2015-01-02 11:30:10 UTC
-header_image: /img/blog/technology-meets-art/header.jpg
+background_image: /img/blog/technology-meets-art/header.jpg
+background_image_source: https://500px.com/photo/51931684/the-moment-by-ash-furrow
 ---
 
 I've done a lot of photography over the Christmas holiday – and I don't mean that I've taken lots of photos. My wife and I have spent a lot of time walking all over Amsterdam, discussing plans for photos we wanted to make, visiting galleries, and developing film. It was just the kind of relaxing time-off that I needed to start off the new year fresh and ready-to-go. It was all kind of kicked off by a [really awesome Youtube series](https://www.youtube.com/playlist?list=PL4F918844C147182A) discussing the history of photography. 

--- a/source/blog/2015-03-12-production-swift.html.markdown
+++ b/source/blog/2015-03-12-production-swift.html.markdown
@@ -2,6 +2,7 @@
 title: Production Swift
 date: 2015-03-12 21:40:53 UTC
 background_image: /img/blog/production-swift/header.jpg
+background_image_source: https://www.flickr.com/photos/97226415@N08/16300562689/in/faves-56453286@N04/
 summary: Before I left Europe, I gave a talk at <a href="http://www.dotswift.io">dotSwift</a>, one of the first conferences focusing exclusively on Apple's new programming language.
 ---
 

--- a/source/blog/2015-04-20-on-turning-27.html.markdown
+++ b/source/blog/2015-04-20-on-turning-27.html.markdown
@@ -2,6 +2,7 @@
 title: On Turning 27
 date: 2015-04-20 22:29:43 UTC
 background_image: /img/blog/on-turning-27/background.jpg
+background_image_source: https://500px.com/photo/91467567/tracks-home-by-ash-furrow
 ---
 
 So I turned 27 last week. And I'm doing that thing where you do a write-up of your year. Orta's idea, and I really like it. I [started last year](http://ashfurrow.com/blog/on-turning-26/) and found the exercise to be cathartic and helpful.

--- a/source/css/custom.less
+++ b/source/css/custom.less
@@ -1,6 +1,23 @@
 @import "variables.less";
 @import "mixins.less";
 
+.header_image_link_container {
+  position: relative;
+
+  a {
+    text-decoration: none;
+
+    i {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      color: rgba(255,255,255,0.5);
+      padding-right: 20px;
+      padding-bottom: 20px;
+    }
+  }
+}
+
 .container .pager li > a {
   margin-top: 10px;
   margin-bottom: 10px;
@@ -109,7 +126,7 @@ blockquote > p:first-child {
 .container {
   .header-link {
     position: absolute;
-    left:-0.5em;
+    left:-0.25em;
     /* The links don't fit on spall screens, so let's high them. */
     @media only screen and (max-width: 768px) {
       display:none;   
@@ -122,6 +139,12 @@ blockquote > p:first-child {
       left: 0.3em;
       display: inline;
     }
+  }
+}
+
+.custom {
+  .header-link {
+    left: -0.75em !important;
   }
 }
 

--- a/source/layouts/_header.erb
+++ b/source/layouts/_header.erb
@@ -1,9 +1,12 @@
 <%
 
 image_name = data.site.default_background_image
-if defined? background_image
-  image_name = background_image 
+custom_image = current_resource.metadata[:page]["background_image"]
+if custom_image && custom_image.length > 0
+  image_name = current_resource.metadata[:page]["background_image"]
 end
+
+background_image_source = current_resource.metadata[:page]["background_image_source"]
 
 header_style = "site-heading"
 if defined? style
@@ -27,6 +30,15 @@ else
       eos
 end
 
+image_source_element = ""
+if background_image_source
+  image_source_element = <<-eos
+  <div class="header_image_link_container">
+    <a href="#{background_image_source}"><i class="fa fa-picture-o"></i></a>
+  </div>
+  eos
+end
+
 %>
 
 <header class="intro-header" id="image-header" style="background-image: url('<%= image_name %>');">
@@ -37,4 +49,5 @@ end
       </div>
     </div>
   </div>
+  <%= image_source_element %>
 </header>

--- a/source/layouts/blog_post.erb
+++ b/source/layouts/blog_post.erb
@@ -1,14 +1,7 @@
 <% wrap_layout :layout do %>
+
   <!-- Page Header -->
-  <%= 
-    locals = { :title => current_article.title, :subtitle => "", :style => "post-heading" }
-    background_image = current_resource.metadata[:page]["header_image"] 
-    background_image ||= current_resource.metadata[:page]["background_image"]
-    if background_image
-      locals.merge!({ :background_image => background_image })
-    end
-    partial("header", :locals => locals) 
-  %>
+  <%= partial("header", :locals => { :title => current_article.title, :subtitle => "", :style => "post-heading" }) %>
 
   <div class="container">
     <div class="row">

--- a/source/layouts/custom_blog_post.erb
+++ b/source/layouts/custom_blog_post.erb
@@ -1,16 +1,11 @@
 <% wrap_layout :layout do %>
-  <!-- Page Header -->
-  <%= 
-    locals = { :title => current_article.title, :subtitle => "", :style => "post-heading" }
-    background_image = current_resource.metadata[:page]["header_image"] 
-    background_image ||= current_resource.metadata[:page]["background_image"]
-    if background_image
-      locals.merge!({ :background_image => background_image })
-    end
-    partial("header", :locals => locals) 
-  %>
 
-  <%= yield %>
+  <!-- Page Header -->
+  <%= partial("header", :locals => { :title => current_article.title, :subtitle => "", :style => "post-heading" }) %>
+
+  <div class="custom">
+    <%= yield %>
+  </div>
 
   <div class="container">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">


### PR DESCRIPTION
In the bottom-right corner: 

![screen shot 2015-05-01 at 10 13 43 pm](https://cloud.githubusercontent.com/assets/498212/7436590/5f65b352-f04f-11e4-9c37-ebb2a3ec7a95.png)

Also consolidates some different logic into one partial, and fixes a problem with header links in custom blog layouts. 

Fixes #32.