### PR TITLE
Updates code text colour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem "middleman", "~> 3.3.6"
-gem "middleman-blog", "~> 3.5.3"
+gem "middleman"
+gem "middleman-blog"
 gem "middleman-s3_sync"  
 gem "middleman-cloudfront"
 gem "middleman-syntax"
@@ -12,4 +12,4 @@ gem "therubyracer"
 gem "less"
 
 # For feed.xml.builder
-gem "builder", "~> 3.0"
+gem "builder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,11 +195,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  builder (~> 3.0)
+  builder
   less
   liquid
-  middleman (~> 3.3.6)
-  middleman-blog (~> 3.5.3)
+  middleman
+  middleman-blog
   middleman-cloudfront
   middleman-s3_sync
   middleman-syntax

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Thanks to the following people and projects:
 - [middleman-syntax](https://github.com/middleman/middleman-syntax)
 - [Font Awesome](http://fortawesome.github.io/Font-Awesome/icons/)
 - [This colour](http://www.colourlovers.com/color/398CCC/Walton)
+- [This colour scheme](http://www.colourlovers.com/palette/869489/Caribbean_Dusk)
 - [s3cmd](http://s3tools.org/)
 - [vertical timeline jquery thingy](http://www.jqueryscript.net/other/Responsive-Vertical-Timeline-With-jQuery-CSS3.html)
 

--- a/lib/ubiquity.rb
+++ b/lib/ubiquity.rb
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*- #
+
+# Custom code-highlighting theme for mah blerg.
+
+module Rouge
+  module Themes
+    class Ubiquity < CSSTheme
+      walton            = '#398CCC'
+      walton_dark       = '#456CCC'
+      walton_light      = '#39B6CC'
+      black             = '#404040'
+      gray              = '#808080'
+      gray_light        = '#EEEEEE'
+
+      name 'ubiquity'
+
+      style Comment::Multiline,               :fg => walton_light,:italic => true
+      style Comment::Preproc,                 :fg => gray,        :bold => true
+      style Comment::Single,                  :fg => walton_light,:italic => true
+      style Comment::Special,                 :fg => gray,        :italic => true, :bold => true
+      style Comment,                          :fg => walton_light,:italic => true
+      style Error,                            :fg => walton_light,:bold => true
+      style Generic::Deleted,                 :fg => black,       :bg => walton_light
+      style Generic::Emph,                    :fg => black,       :italic => true
+      style Generic::Error,                   :fg => walton_light
+      style Generic::Heading,                 :fg => gray
+      style Generic::Inserted,                :fg => black
+      style Generic::Output,                  :fg => gray
+      style Generic::Prompt,                  :fg => black
+      style Generic::Strong,                                      :bold => true
+      style Generic::Subheading,              :fg => gray
+      style Generic::Traceback,               :fg => walton_dark
+      style Keyword::Constant,                :fg => black,       :bold => true
+      style Keyword::Declaration,             :fg => black,       :bold => true
+      style Keyword::Namespace,               :fg => black,       :bold => true
+      style Keyword::Pseudo,                  :fg => black,       :bold => true
+      style Keyword::Reserved,                :fg => black,       :bold => true
+      style Keyword::Type,                    :fg => walton_dark, :bold => true
+      style Keyword,                          :fg => black,       :bold => true
+      style Literal::Number::Float,           :fg => walton_light
+      style Literal::Number::Hex,             :fg => walton_light
+      style Literal::Number::Integer::Long,   :fg => walton_light
+      style Literal::Number::Integer,         :fg => walton_light
+      style Literal::Number::Oct,             :fg => walton_light
+      style Literal::Number,                  :fg => walton_light
+      style Literal::String::Backtick,        :fg => walton_light
+      style Literal::String::Char,            :fg => walton_light
+      style Literal::String::Doc,             :fg => walton_light
+      style Literal::String::Double,          :fg => walton_light
+      style Literal::String::Escape,          :fg => walton_light
+      style Literal::String::Heredoc,         :fg => walton_light
+      style Literal::String::Interpol,        :fg => walton_light
+      style Literal::String::Other,           :fg => walton_light
+      style Literal::String::Regex,           :fg => walton
+      style Literal::String::Single,          :fg => walton_light
+      style Literal::String::Symbol,          :fg => walton
+      style Literal::String,                  :fg => walton_light
+      style Name::Attribute,                  :fg => walton
+      style Name::Builtin::Pseudo,            :fg => gray
+      style Name::Builtin,                    :fg => walton_dark
+      style Name::Class,                      :fg => walton_dark, :bold => true
+      style Name::Constant,                   :fg => walton
+      style Name::Decorator,                  :fg => gray,        :bold => true
+      style Name::Entity,                     :fg => walton
+      style Name::Exception,                  :fg => walton_light,:bold => true
+      style Name::Function,                   :fg => walton_light,:bold => true
+      style Name::Label,                      :fg => walton_light,:bold => true
+      style Name::Namespace,                  :fg => gray
+      style Name::Tag,                        :fg => black
+      style Name::Variable::Class,            :fg => walton
+      style Name::Variable::Global,           :fg => walton
+      style Name::Variable::Instance,         :fg => walton
+      style Name::Variable,                   :fg => walton
+      style Operator::Word,                   :fg => black,       :bold => true
+      style Operator,                         :fg => black,       :bold => true
+      style Text::Whitespace,                 :fg => gray
+    end
+  end
+end

--- a/source/css/custom.less
+++ b/source/css/custom.less
@@ -1,6 +1,10 @@
 @import "variables.less";
 @import "mixins.less";
 
+code {
+  color: @brand-primary;
+}
+
 .header_image_link_container {
   position: relative;
 

--- a/source/css/custom.less
+++ b/source/css/custom.less
@@ -1,8 +1,9 @@
 @import "variables.less";
 @import "mixins.less";
 
-code {
+code, pre {
   color: @brand-primary;
+  background-color: @gray-light;
 }
 
 .header_image_link_container {

--- a/source/css/syntax.css.erb
+++ b/source/css/syntax.css.erb
@@ -1,1 +1,7 @@
-<%= Rouge::Themes::Github.render(:scope => '.highlight') %>
+<%= 
+
+require 'lib/ubiquity'
+
+Rouge::Themes::Ubiquity.render(:scope => '.highlight') 
+
+%>


### PR DESCRIPTION
Right now, we're using a Rouge theme in [syntax.css.erb](https://github.com/ashfurrow/blog/blob/master/source/css/syntax.css.erb). I took a look at the theme we're using, the [`GitHub` theme](https://github.com/jneen/rouge/blob/master/lib/rouge/themes/github.rb), and it's not complicated, just long. It should be straightforward to make my own Rouge colour theme and use it to render code blocks, instead. 

For now, I've changed the CSS for `<code>` tags, which aren't touched by Rouge.

Fixes #23.