### PR TITLE
Fix for article pager widths

### DIFF
--- a/source/css/custom.less
+++ b/source/css/custom.less
@@ -23,15 +23,25 @@ code, pre {
   }
 }
 
-.container .pager li > a {
-  margin-top: 10px;
-  margin-bottom: 10px;
-  text-decoration: none;
-}
+.container .pager li {
+  a {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    text-decoration: none;
+    overflow: hidden;
+    width: 100%;
 
-.article_pager li > a {
-  width: 100%;
-  text-align: left;
+    /* Small devices (tablets, 768px and up) */
+    @media (min-width: 768px) {
+      width: 45%;
+    }
+
+    div {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 }
 
 #page_footer {

--- a/source/css/custom.less
+++ b/source/css/custom.less
@@ -29,6 +29,11 @@ code, pre {
   text-decoration: none;
 }
 
+.article_pager li > a {
+  width: 100%;
+  text-align: left;
+}
+
 #page_footer {
   margin-top: 20px;
 }

--- a/source/layouts/_article_pager.erb
+++ b/source/layouts/_article_pager.erb
@@ -1,13 +1,13 @@
 <!-- Pager -->
-<ul class="article_pager pager">
+<ul class="pager">
   <% if current_article.next_article %>
     <li class="next">
-        <%= link_to "&rarr; #{current_article.next_article.title}", current_article.next_article.url %>
+        <%= link_to "<div>#{current_article.next_article.title}</div>", current_article.next_article.url %>
     </li>
   <% end %>
   <% if current_article.previous_article %>
     <li class="previous">
-        <%= link_to "&larr; #{current_article.previous_article.title}", current_article.previous_article.url %>
+        <%= link_to "<div>#{current_article.previous_article.title}</div>", current_article.previous_article.url %>
     </li>
   <% end %>
   

--- a/source/layouts/_article_pager.erb
+++ b/source/layouts/_article_pager.erb
@@ -1,8 +1,8 @@
 <!-- Pager -->
-<ul class="pager">
+<ul class="article_pager pager">
   <% if current_article.next_article %>
     <li class="next">
-        <%= link_to "#{current_article.next_article.title} &rarr;", current_article.next_article.url %>
+        <%= link_to "&rarr; #{current_article.next_article.title}", current_article.next_article.url %>
     </li>
   <% end %>
   <% if current_article.previous_article %>


### PR DESCRIPTION
Dunno if I like the design, buy my original idea of using ellipses doesn't work without redoing the whole pager border math, and I don't really care that much. 

This keeps the blog list pagers the same:

![screen shot 2015-05-20 at 12 05 41 pm](https://cloud.githubusercontent.com/assets/498212/7723439/ddec42c0-fee8-11e4-8764-72262cb904e6.png)

But changes the pagers on articles to be full-width:

![screen shot 2015-05-20 at 12 05 49 pm](https://cloud.githubusercontent.com/assets/498212/7723444/e7974fcc-fee8-11e4-9ba2-92b53968f871.png)

Which look a _bit_ silly I think at bigger widths, but good at smaller ones:

![screen shot 2015-05-20 at 12 06 00 pm](https://cloud.githubusercontent.com/assets/498212/7723450/f3c7121e-fee8-11e4-80c3-6907b8622e04.png)

Got me thinking about why I need pagers at all. 

Fixes #60.