### PR TITLE
Allow blockquotes to breath

### DIFF
--- a/source/css/_custom.css.scss
+++ b/source/css/_custom.css.scss
@@ -374,6 +374,7 @@ blockquote {
   margin: 2em 0;
   font-style: normal;
   color: $gray;
+  line-height: 40px;
 
   /* Makes bold text in blockquotes really pop */
   strong, b, em {


### PR DESCRIPTION
Was just reading your post about iOS and JS and couldn't help but notice that the blockquotes were suffocating so I took a stab at helping:

### before

<img width="1392" alt="Screen Shot 2019-03-25 at 9 09 23 AM" src="https://user-images.githubusercontent.com/79799/54926366-2dd2b280-4ede-11e9-82ec-3f30299a1cac.png">

### after

<img width="1392" alt="Screen Shot 2019-03-25 at 9 09 25 AM" src="https://user-images.githubusercontent.com/79799/54926378-332ffd00-4ede-11e9-94b2-59d49b4ba742.png">

I confess that I did not actually clone down the repo and verify that this diff fixes it - I just did it with the Chrome Dev Tools and then found where I thought the CSS change would be.

I realize that this is a very strange PR, but if you're into it, then great - otherwise feel free to ignore! 😉 