### PR TITLE
Fix typo in "Critical programming" post

### DIFF
--- a/blog/2020-09-30-critical-programming/index.mdx
+++ b/blog/2020-09-30-critical-programming/index.mdx
@@ -39,7 +39,7 @@ Programming languages are an important part of your toolbox, but the skill of th
 
 From my experience, this message of "Hey programmers! You should learn other programming languages!" is a very tough sell. When I tell programmers this, they resist. "But programmers should be all about learning programming languages, right? That's their whole deal.", you might think. But from the perspective of programmers, it actually makes a lot of sense.
 
-There are two reasons that programmers reluctant to learn new languages. 
+There are two reasons that make programmers reluctant to learn new languages. 
 
 The first is that learning a new language is difficult. I mean, yeah! It is! If you're a new programmer, you're already inundated with learning your _first_ language, so the idea of learning _another_ language (and then another! another!) is going to feel completely overwhelming. If you're an experienced programmer, you'll face a similar problem: you are so used to being an expert with the tool you already know that learning a new language _feels_ bad. You aren't as productive as you were with the tool you already know. You get frustrated. It sucks feeling like a beginner!
 
@@ -50,4 +50,3 @@ The second problem that makes programmers reluctant to learn new languages is th
 So I understand why programmers are reluctant to branch out, to learn new things. It's difficult and it sucks, but it's worth it. Programmers who are really deeply rooted in one specific community experience these problems compounded even further. Since iOS is what I know best, I have tended to focus on iOS developers when I talk about branching out and learning new tools. I've tried to avoid that in this blog post and speak from my own experiences. If I've ever [been critical](/blog/thinking-critically-about-apple/) of the tools you know and love, and it's made you feel bad, I'm sorry. I promise that it came from a place of caring, of respect, and of wanting you to reach your full potential as a craftsperson.
 
 With all that said, and with full knowledge of the humiliation I felt that summer in high school, of the humility it helped me ultimately find, and coming from a place of genuine care and compassion, I'll ask you the same question that Mrs McLean asked me: "You say that your favourite programming language is really great but, realistically, how many languages have you actually learned?"
-


### PR DESCRIPTION
Hi there! 

Really interesting post, I enjoyed it.

 This little change adds `make` in the `There are two reasons that programmers reluctant to learn new languages` section of the `Critical Programming` post.