### PR TITLE
Fix typo

### DIFF
--- a/blog/2020-12-30-restoring-a-postgres-mastodon-database/index.mdx
+++ b/blog/2020-12-30-restoring-a-postgres-mastodon-database/index.mdx
@@ -193,7 +193,7 @@ I'm still pondering why adding a foreign key would take so long on an otherwise 
 
 ## Conclusion
 
-Overall, I'm very happy with how today went. I didn't really need to do much excpet check in now and then. In fact, the process benefited from some "benign neglect" and I only did harm by intervening.
+Overall, I'm very happy with how today went. I didn't really need to do much except check in now and then. In fact, the process benefited from some "benign neglect" and I only did harm by intervening.
 
 On disk, the old database was 96GB large. The new one is 63GB. Turns out that database vacuuming is important. 
 


### PR DESCRIPTION
Fix typo in "Restoring a Postgres Mastodon Database"

`excpet` to `except`